### PR TITLE
Use ILogger in UnitOfWork

### DIFF
--- a/api-rauscher/Data/UoW/UnitOfWork.cs
+++ b/api-rauscher/Data/UoW/UnitOfWork.cs
@@ -1,5 +1,6 @@
-﻿using Data.Context;
+using Data.Context;
 using Domain.Interfaces;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace Data.UoW
@@ -7,10 +8,12 @@ namespace Data.UoW
   public class UnitOfWork : IUnitOfWork
   {
     private readonly RauscherDbContext _context;
+    private readonly ILogger<UnitOfWork> _logger;
 
-    public UnitOfWork(RauscherDbContext context)
+    public UnitOfWork(RauscherDbContext context, ILogger<UnitOfWork> logger)
     {
       _context = context;
+      _logger = logger;
     }
 
     public bool Commit()
@@ -21,7 +24,7 @@ namespace Data.UoW
       }
       catch (Exception e)
       {
-        Console.WriteLine(e.InnerException);
+        _logger.LogError(e, "Error committing changes to the database");
         throw;
       }
     }


### PR DESCRIPTION
## Summary
- inject `ILogger<UnitOfWork>` into UnitOfWork
- log caught exceptions with logger instead of writing to console

## Testing
- `dotnet build api-rauscher.sln --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686706f8872883289672cd57f8e80f52