### PR TITLE
Use Npgsql for database contexts

### DIFF
--- a/RauscherFunctionsAPI/Configurations/DatabaseSetup.cs
+++ b/RauscherFunctionsAPI/Configurations/DatabaseSetup.cs
@@ -28,13 +28,13 @@ namespace RauscherFunctionsAPI.Configurations
 
       // Registrar os contextos de banco de dados no container de dependências
       services.AddDbContext<EventStoreSQLContext>(options =>
-          options.UseSqlServer(connectionString));
+          options.UseNpgsql(connectionString));
 
       services.AddDbContext<RauscherDbContext>(options =>
-          options.UseSqlServer(connectionString));
+          options.UseNpgsql(connectionString));
 
       services.AddDbContext<ApiSecurityDbContext>(options =>
-          options.UseSqlServer(connectionString));
+          options.UseNpgsql(connectionString));
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace SQL Server provider with Npgsql in DatabaseSetup

## Testing
- `dotnet test` *(fails: command not found)*
- `bash dotnet-install.sh` *(fails: 403 Unable to download)*

------
https://chatgpt.com/codex/tasks/task_e_688d1227be088328b1f7f8cfef9b7a2a