### PR TITLE
Use provider-neutral column types in event store

### DIFF
--- a/api-rauscher/Data/Context/EventStoreSQLContext.cs
+++ b/api-rauscher/Data/Context/EventStoreSQLContext.cs
@@ -40,11 +40,11 @@ namespace Data.Context
       {
         entity.Property(c => c.Id)
                   .HasColumnName("Id")
-                  .HasColumnType("uniqueidentifier");
+                  .HasColumnType("uuid");
 
         entity.Property(c => c.AggregateId)
                   .HasColumnName("AggregateId")
-                  .HasColumnType("uniqueidentifier");
+                  .HasColumnType("uuid");
 
         entity.Property(c => c.TimeStamp)
               .HasColumnName("CreationDate");
@@ -55,11 +55,11 @@ namespace Data.Context
 
         entity.Property(c => c.Data)
                   .HasColumnName("Data")
-                  .HasColumnType("varchar(max)");
+                  .HasColumnType("text");
 
         entity.Property(c => c.ActionUser)
                   .HasColumnName("ActionUser")
-                  .HasColumnType("varchar(max)");
+                  .HasColumnType("text");
       });
 
       OnModelCreatingPartial(modelBuilder);


### PR DESCRIPTION
## Summary
- make event store context use provider-neutral types

## Testing
- `dotnet build` *(fails: command not found)*
- `../dotnet-install.sh` *(fails: 403 Unable to download)*

------
https://chatgpt.com/codex/tasks/task_e_688d14b8cfb483288c061fc034e6ffd1