### PR TITLE
Switch to Npgsql provider

### DIFF
--- a/RauscherFunctionsAPI/Configurations/DatabaseSetup.cs
+++ b/RauscherFunctionsAPI/Configurations/DatabaseSetup.cs
@@ -28,13 +28,13 @@ namespace RauscherFunctionsAPI.Configurations
 
       // Registrar os contextos de banco de dados no container de dependências
       services.AddDbContext<EventStoreSQLContext>(options =>
-          options.UseSqlServer(connectionString));
+          options.UseNpgsql(connectionString));
 
       services.AddDbContext<RauscherDbContext>(options =>
-          options.UseSqlServer(connectionString));
+          options.UseNpgsql(connectionString));
 
       services.AddDbContext<ApiSecurityDbContext>(options =>
-          options.UseSqlServer(connectionString));
+          options.UseNpgsql(connectionString));
     }
   }
 }

--- a/api-rauscher/Api/Api.csproj
+++ b/api-rauscher/Api/Api.csproj
@@ -24,8 +24,8 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.26" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.26">
+                <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.20" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.26">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/api-rauscher/Api/Configurations/DatabaseSetup.cs
+++ b/api-rauscher/Api/Configurations/DatabaseSetup.cs
@@ -18,12 +18,12 @@ namespace Api.Configurations
       if (services == null) throw new ArgumentNullException(nameof(services));
 
       services.AddDbContext<EventStoreSQLContext>(options =>
-          options.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
+          options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
 
       services.AddDbContext<RauscherDbContext>(options =>
-          options.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
+          options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
       services.AddDbContext<ApiSecurityDbContext>(options =>
-          options.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
+          options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
     }
   }
 }

--- a/api-rauscher/Api/appsettings.json
+++ b/api-rauscher/Api/appsettings.json
@@ -4,7 +4,7 @@
     //"DefaultConnection": "Server=tcp:rasuchersql.database.windows.net,1433;Initial Catalog=rauscher-sql;Persist Security Info=False;User ID=db;Password=Vini#1234;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     //Development
     //"DefaultConnection": "Server=127.0.0.1,1433;Initial Catalog=RauscherApp;Persist Security Info=False;User ID=sa;Password=V1ni#0785;MultipleActiveResultSets=False;Encrypt=False;TrustServerCertificate=False;Connection Timeout=30;"
-    "DefaultConnection": "Server=espuridb.cjm2i6ak2578.us-east-2.rds.amazonaws.com,1433;Database=rauscherapp;User Id=admin;Password=QtcGVcoPKy5GY0gwslNZ;"
+    "DefaultConnection": "Host=espuridb.cjm2i6ak2578.us-east-2.rds.amazonaws.com;Port=5432;Database=rauscherapp;Username=admin;Password=QtcGVcoPKy5GY0gwslNZ;"
   },
   "CommoditiesApi": {
     "BaseUrl": "https://commodities-api.com/api/",

--- a/api-rauscher/Data.Migrations/Context/RauscherDbContextFactory.cs
+++ b/api-rauscher/Data.Migrations/Context/RauscherDbContextFactory.cs
@@ -17,10 +17,10 @@ namespace Data.Migrations.Context
                 .AddJsonFile("appsettings.json", optional: false)
                 .Build();
 
-            var connectionString = "Server=tcp:rauscher-db.database.windows.net,1433;Initial Catalog=db_rauscher;Persist Security Info=False;User ID=adminsql;Password=Rauscher@2025*;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;";
+            var connectionString = "Host=rauscher-db.database.windows.net;Port=5432;Database=db_rauscher;Username=adminsql;Password=Rauscher@2025*;";
 
             var optionsBuilder = new DbContextOptionsBuilder<RauscherDbContext>();
-            optionsBuilder.UseSqlServer(connectionString,
+            optionsBuilder.UseNpgsql(connectionString,
                 b => b.MigrationsAssembly("Data.Migrations"));
 
             return new RauscherDbContext(optionsBuilder.Options);

--- a/api-rauscher/Data/Context/EventStoreSQLContext.cs
+++ b/api-rauscher/Data/Context/EventStoreSQLContext.cs
@@ -30,7 +30,7 @@ namespace Data.Context
             .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json", optional: true)
             .Build();
 
-        optionsBuilder.UseSqlServer(config.GetConnectionString("DefaultConnection"));
+        optionsBuilder.UseNpgsql(config.GetConnectionString("DefaultConnection"));
       }
     }
 

--- a/api-rauscher/Data/Context/RauscherDbContext.cs
+++ b/api-rauscher/Data/Context/RauscherDbContext.cs
@@ -38,7 +38,7 @@ namespace Data.Context
             .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json", optional: true)
             .Build();
 
-        optionsBuilder.UseSqlServer(config.GetConnectionString("DefaultConnection"));
+        optionsBuilder.UseNpgsql(config.GetConnectionString("DefaultConnection"));
       }
     }
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/api-rauscher/Data/Data.csproj
+++ b/api-rauscher/Data/Data.csproj
@@ -8,8 +8,8 @@
 		<PackageReference Include="Dapper" Version="2.0.123" />
 		<PackageReference Include="Dapper.Contrib" Version="2.0.78" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.26" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.26" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.26">
+                <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.20" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.26">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/api-rauscher/Data/appsettings.json
+++ b/api-rauscher/Data/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=vm-stksys;Database=testeEstoque;User ID=sistemas;Password=uncalled;MultipleActiveResultSets=True;"
-  },  
+    "DefaultConnection": "Host=vm-stksys;Port=5432;Database=testeEstoque;Username=sistemas;Password=uncalled;"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- migrate EF Core contexts and configuration from SQL Server to Npgsql
- update connection strings for PostgreSQL

## Testing
- `dotnet build api-rauscher.sln` *(fails: Failed to retrieve information about 'Npgsql.EntityFrameworkCore.PostgreSQL' from remote source)*

------
https://chatgpt.com/codex/tasks/task_e_688d13cf7d708328ad6b23aac49eea8a