### PR TITLE
chore: configure migrations for PostgreSQL

### DIFF
--- a/api-rauscher/Data.Migrations/Context/RauscherDbContextFactory.cs
+++ b/api-rauscher/Data.Migrations/Context/RauscherDbContextFactory.cs
@@ -17,10 +17,10 @@ namespace Data.Migrations.Context
                 .AddJsonFile("appsettings.json", optional: false)
                 .Build();
 
-            var connectionString = "Server=tcp:rauscher-db.database.windows.net,1433;Initial Catalog=db_rauscher;Persist Security Info=False;User ID=adminsql;Password=Rauscher@2025*;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;";
+            var connectionString = "Host=167.71.90.85;Username=rauscheradmin;Password=R4u$Ch3R*2025;Database=<nome>";
 
             var optionsBuilder = new DbContextOptionsBuilder<RauscherDbContext>();
-            optionsBuilder.UseSqlServer(connectionString,
+            optionsBuilder.UseNpgsql(connectionString,
                 b => b.MigrationsAssembly("Data.Migrations"));
 
             return new RauscherDbContext(optionsBuilder.Options);

--- a/api-rauscher/Data.Migrations/Data.Migrations.csproj
+++ b/api-rauscher/Data.Migrations/Data.Migrations.csproj
@@ -5,5 +5,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Data\Data.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.26" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- configure migrations to target PostgreSQL
- add Npgsql provider to migrations project

## Testing
- `dotnet build api-rauscher/Data.Migrations/Data.Migrations.csproj -c Release` *(fails: command not found)*
- `./dotnet-install.sh --channel 6.0 --install-dir $HOME/dotnet` *(fails: 403 Unable to download)*

------
https://chatgpt.com/codex/tasks/task_e_688d188262108328ba4acc5855472bfb