### PR TITLE
Switch EF Core provider to Npgsql

### DIFF
--- a/api-rauscher/Api/Api.csproj
+++ b/api-rauscher/Api/Api.csproj
@@ -24,12 +24,13 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.26" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.26">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.26">
+                        <PrivateAssets>all</PrivateAssets>
+                        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                </PackageReference>
+                <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.10" />
+                <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="6.0.10" />
+                <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" />
 		<PackageReference Include="RabbitMQ.Client" Version="6.3.0" />
 		<PackageReference Include="Serilog.Enrichers.Demystifier" Version="1.0.2" />
 		<PackageReference Include="Serilog.Exceptions" Version="8.1.0" />

--- a/api-rauscher/Data/Data.csproj
+++ b/api-rauscher/Data/Data.csproj
@@ -8,12 +8,13 @@
 		<PackageReference Include="Dapper" Version="2.0.123" />
 		<PackageReference Include="Dapper.Contrib" Version="2.0.78" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.26" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.26" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.26">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.2" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.26">
+                        <PrivateAssets>all</PrivateAssets>
+                        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                </PackageReference>
+                <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.10" />
+                <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="6.0.10" />
+                <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.2" />
 	</ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- replace Microsoft.EntityFrameworkCore.SqlServer with Npgsql.EntityFrameworkCore.PostgreSQL in Data and Api projects
- add Npgsql.EntityFrameworkCore.PostgreSQL.Design package where appropriate

## Testing
- `dotnet restore api-rauscher.sln` *(failed: command not found)*
- `./dotnet-install.sh --channel 6.0 --install-dir $HOME/.dotnet` *(failed: download 403)*

------
https://chatgpt.com/codex/tasks/task_e_688d1a4343548328ab0811242dccacfd