### PR TITLE
Return uploaded post after image upload

### DIFF
--- a/RauscherFunctionsAPI/Functions/PostFunction.cs
+++ b/RauscherFunctionsAPI/Functions/PostFunction.cs
@@ -171,14 +171,14 @@ namespace RauscherFunctionsAPI
 
       try
       {
-        var imageUrl = await _postAppService.UploadPostImage(id, file);
+        var post = await _postAppService.UploadPostImage(id, file);
 
-        if (imageUrl)
+        if (post == null)
         {
           return CreateResponse(false);
         }
 
-        return CreateResponse(new { ImageUrl = imageUrl });
+        return CreateResponse(post);
       }
       catch (Exception ex)
       {

--- a/api-rauscher/Application.Tests/Application.Tests.csproj
+++ b/api-rauscher/Application.Tests/Application.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+</Project>

--- a/api-rauscher/Application.Tests/PostAppServiceTests.cs
+++ b/api-rauscher/Application.Tests/PostAppServiceTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Interfaces;
+using Application.Services;
+using Application.ViewModels;
+using AutoMapper;
+using Domain.Commands;
+using Domain.Models;
+using Domain.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Application.Tests
+{
+    public class PostAppServiceTests
+    {
+        [Fact]
+        public async Task UploadPostImage_Returns_PostWithUpdatedImageUrl()
+        {
+            // Arrange
+            var mediator = new Mock<IMediator>();
+            var logger = new Mock<ILogger<PostAppService>>();
+            var uriApp = new Mock<IUriAppService>();
+
+            var mapperConfig = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Post, PostViewModel>();
+            });
+            var mapper = mapperConfig.CreateMapper();
+
+            var service = new PostAppService(logger.Object, mediator.Object, mapper, uriApp.Object);
+
+            var postId = Guid.NewGuid();
+            var post = new Post(postId, "title", DateTime.UtcNow, "content", "author", true, Guid.NewGuid(), "en");
+            post.SetImageUrl("uploads/posts/image.jpg");
+
+            mediator.Setup(m => m.Send(It.IsAny<UploadPostImageCommand>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+            mediator.Setup(m => m.Send(It.IsAny<ObterPostQuery>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(post);
+
+            var bytes = new byte[] { 1, 2, 3 };
+            using var stream = new MemoryStream(bytes);
+            var formFile = new FormFile(stream, 0, bytes.Length, "image", "image.jpg");
+
+            // Act
+            var result = await service.UploadPostImage(postId, formFile);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(post.ImgUrl, result.ImgUrl);
+        }
+    }
+}

--- a/api-rauscher/Application/Interfaces/IPostAppService.cs
+++ b/api-rauscher/Application/Interfaces/IPostAppService.cs
@@ -13,7 +13,7 @@ namespace Application.Interfaces
 		Task<PostViewModel> CadastrarPost(PostViewModel postViewModel);
 		Task<bool> ExcluirPost(Guid Post);
 		Task<PostViewModel> ObterPost(Guid Post);
-		Task<PagedResponse<PostViewModel>> ListarPost(PostParameters parameters);
-    Task<bool> UploadPostImage(Guid postId, IFormFile file);
+                Task<PagedResponse<PostViewModel>> ListarPost(PostParameters parameters);
+    Task<PostViewModel> UploadPostImage(Guid postId, IFormFile file);
   }
 }

--- a/api-rauscher/Application/Services/PostAppService.cs
+++ b/api-rauscher/Application/Services/PostAppService.cs
@@ -76,14 +76,20 @@ namespace Application.Services
 			
 			return resultadoDB;
 		}
-    public async Task<bool> UploadPostImage(Guid postId, IFormFile file)
+    public async Task<PostViewModel> UploadPostImage(Guid postId, IFormFile file)
     {
       _logger.LogInformation("Handling: {MethodName}", nameof(UploadPostImage));
 
       var command = new UploadPostImageCommand(postId, file);
       var result = await _mediator.Send(command);
 
-      return result;
+      if (!result)
+      {
+        return null;
+      }
+
+      var post = await _mediator.Send(new ObterPostQuery(postId));
+      return _mapper.Map<Post, PostViewModel>(post);
     }
 
   }


### PR DESCRIPTION
## Summary
- Return PostViewModel from UploadPostImage service and interface
- Update API function to return updated post
- Add unit test verifying UploadPostImage includes ImageUrl

## Testing
- `dotnet test api-rauscher/Application.Tests/Application.Tests.csproj` *(fails: command not found: dotnet)*
- `./dotnet-install.sh --channel 6.0` *(fails: 403 Unable to download)*

------
https://chatgpt.com/codex/tasks/task_e_688e247ebe088328801ca7d3a33c07bf