### PR TITLE
feat: add command to delete post image

### DIFF
--- a/api-rauscher/Domain/Commands/Post/DeletePostImageCommand.cs
+++ b/api-rauscher/Domain/Commands/Post/DeletePostImageCommand.cs
@@ -1,0 +1,19 @@
+using Domain.Validations;
+using System;
+
+namespace Domain.Commands
+{
+  public class DeletePostImageCommand : PostCommand
+  {
+    public DeletePostImageCommand(Guid id)
+    {
+      ID = id;
+    }
+
+    public override bool IsValid()
+    {
+      ValidationResult = new DeletePostImageCommandValidation().Validate(this);
+      return ValidationResult.IsValid;
+    }
+  }
+}

--- a/api-rauscher/Domain/Validations/Post/DeletePostImageCommandValidation.cs
+++ b/api-rauscher/Domain/Validations/Post/DeletePostImageCommandValidation.cs
@@ -1,0 +1,13 @@
+using Domain.Commands;
+using FluentValidation;
+
+namespace Domain.Validations
+{
+            public class DeletePostImageCommandValidation : PostCommandValidation<DeletePostImageCommand>
+        {
+                public DeletePostImageCommandValidation()
+                {
+                            ValidateId();
+                }
+        }
+}


### PR DESCRIPTION
## Summary
- add DeletePostImageCommand to support removing post images
- ensure command validates post identifier via DeletePostImageCommandValidation

## Testing
- `/root/.dotnet/dotnet build api-rauscher/Domain/Domain.csproj`

------
https://chatgpt.com/codex/tasks/task_e_688e2e2b766083288cdc0ee2743a1db8