### PR TITLE
feat: add handler to delete post image

### DIFF
--- a/api-rauscher/Domain/CommandHandlers/Post/DeletePostImageCommandHandler.cs
+++ b/api-rauscher/Domain/CommandHandlers/Post/DeletePostImageCommandHandler.cs
@@ -1,0 +1,58 @@
+using Domain.Commands;
+using Domain.Core.Bus;
+using Domain.Core.Notifications;
+using Domain.Interfaces;
+using Domain.Repositories;
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Domain.CommandHandlers
+{
+  public class DeletePostImageCommandHandler : CommandHandler,
+          IRequestHandler<DeletePostImageCommand, bool>
+  {
+    private readonly IPostRepository _postRepository;
+    private readonly IAzureBlobService _azureBlobService;
+    private readonly IMediatorHandler Bus;
+
+    public DeletePostImageCommandHandler(IPostRepository postRepository,
+                                         IAzureBlobService azureBlobService,
+                                         IUnitOfWork uow,
+                                         IMediatorHandler bus,
+                                         INotificationHandler<DomainNotification> notifications) : base(uow, bus, notifications)
+    {
+      _postRepository = postRepository;
+      _azureBlobService = azureBlobService;
+      Bus = bus;
+    }
+
+    public async Task<bool> Handle(DeletePostImageCommand message, CancellationToken cancellationToken)
+    {
+      if (!message.IsValid())
+      {
+        NotifyValidationErrors(message);
+        return false;
+      }
+
+      var post = _postRepository.GetById(message.PostId);
+      if (post == null)
+      {
+        Bus.RaiseEvent(new DomainNotification(nameof(DeletePostImageCommand), "Post not found."));
+        return false;
+      }
+
+      var result = await _azureBlobService.DeleteAsync(post.ImgUrl);
+      if (!result)
+      {
+        Bus.RaiseEvent(new DomainNotification(nameof(DeletePostImageCommand), "Error deleting image from Azure."));
+        return false;
+      }
+
+      post.SetImageUrl(null);
+      _postRepository.Update(post);
+
+      return Commit();
+    }
+  }
+}

--- a/api-rauscher/Domain/Commands/Post/DeletePostImageCommand.cs
+++ b/api-rauscher/Domain/Commands/Post/DeletePostImageCommand.cs
@@ -1,0 +1,20 @@
+using Domain.Core.Commands;
+using System;
+
+namespace Domain.Commands
+{
+  public class DeletePostImageCommand : PostCommand
+  {
+    public DeletePostImageCommand(Guid postId)
+    {
+      PostId = postId;
+    }
+
+    public Guid PostId { get; }
+
+    public override bool IsValid()
+    {
+      return PostId != Guid.Empty;
+    }
+  }
+}

--- a/api-rauscher/Domain/Interfaces/IAzureBlobService.cs
+++ b/api-rauscher/Domain/Interfaces/IAzureBlobService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Domain.Interfaces
+{
+  public interface IAzureBlobService
+  {
+    Task<bool> DeleteAsync(string blobUrl);
+  }
+}


### PR DESCRIPTION
## Summary
- add delete command and handler for removing post images
- define Azure blob service interface

## Testing
- `dotnet build api-rauscher.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e2fb47bcc8328b87d218c8196f6f1