### PR TITLE
Add post image deletion support and Azure blob service

### DIFF
--- a/api-rauscher/Api/Controllers/Api/PostController.cs
+++ b/api-rauscher/Api/Controllers/Api/PostController.cs
@@ -112,5 +112,23 @@ namespace Api.Controllers
       var result = await _postAppService.ExcluirPost(id);
       return CreateResponse(result);
     }
+
+    [HttpDelete("Post/{id}/Image")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [AllowAnonymous]
+    public async Task<IActionResult> DeletePostImage(Guid id)
+    {
+      if (!IsValidOperation())
+      {
+        return BadRequest(new
+        {
+          success = false,
+          errors = GetNotificationMessages()
+        });
+      }
+
+      var result = await _postAppService.DeletePostImage(id);
+      return CreateResponse(result);
+    }
   }
 }

--- a/api-rauscher/Application/Interfaces/IPostAppService.cs
+++ b/api-rauscher/Application/Interfaces/IPostAppService.cs
@@ -11,9 +11,10 @@ namespace Application.Interfaces
 	{
 		Task<PostViewModel> AtualizarPost(PostViewModel postViewModel);
 		Task<PostViewModel> CadastrarPost(PostViewModel postViewModel);
-		Task<bool> ExcluirPost(Guid Post);
-		Task<PostViewModel> ObterPost(Guid Post);
-		Task<PagedResponse<PostViewModel>> ListarPost(PostParameters parameters);
+                Task<bool> ExcluirPost(Guid Post);
+                Task<PostViewModel> ObterPost(Guid Post);
+                Task<PagedResponse<PostViewModel>> ListarPost(PostParameters parameters);
     Task<bool> UploadPostImage(Guid postId, IFormFile file);
+    Task<bool> DeletePostImage(Guid postId);
   }
 }

--- a/api-rauscher/Application/Services/PostAppService.cs
+++ b/api-rauscher/Application/Services/PostAppService.cs
@@ -86,5 +86,15 @@ namespace Application.Services
       return result;
     }
 
+    public async Task<bool> DeletePostImage(Guid postId)
+    {
+      _logger.LogInformation("Handling: {MethodName}", nameof(DeletePostImage));
+
+      var command = new DeletePostImageCommand(postId);
+      var result = await _mediator.Send(command);
+
+      return result;
+    }
+
   }
 }

--- a/api-rauscher/CrossCutting.IoC/DependencyInjector.cs
+++ b/api-rauscher/CrossCutting.IoC/DependencyInjector.cs
@@ -16,6 +16,7 @@ using Domain.CommandHandlers.Apicredentials;
 using Domain.Commands;
 using Domain.Commands.Apicredentials;
 using Domain.Interfaces;
+using Domain.Services;
 using Domain.Models;
 using Domain.Queries;
 using Domain.QueryHandlers;
@@ -51,6 +52,7 @@ namespace CrossCutting.IoC
       services.AddTransient<IStripeCustomerService, StripeCustomerService>();
       services.AddTransient<IStripeSessionService, StripeSessionService>();
       services.AddTransient<IStripeSubscriptionService, StripeSubscriptionService>();
+      services.AddTransient<IAzureBlobService, AzureBlobService>();
 
 
       //Commands
@@ -82,6 +84,7 @@ namespace CrossCutting.IoC
       services.AddTransient<IRequestHandler<AtualizarAboutUsCommand, bool>, AtualizarAboutUsCommandHandler>();
       services.AddTransient<IRequestHandler<AtualizarOHLCCommoditiesRateCommand, bool>, AtualizarOHLCCommoditiesRateCommandHandler>();
       services.AddTransient<IRequestHandler<UploadPostImageCommand, bool>, UploadPostImageCommandHandler>();
+      services.AddTransient<IRequestHandler<DeletePostImageCommand, bool>, DeletePostImageCommandHandler>();
 
       //Queries
       services.AddTransient<IRequestHandler<ListarSymbolsWithRateQuery, PagedList<Symbols>>, ListarSymbolsWithRateQueryHandler>();

--- a/api-rauscher/CrossCutting.IoC/NativeInjectorBootStrapper.cs
+++ b/api-rauscher/CrossCutting.IoC/NativeInjectorBootStrapper.cs
@@ -83,6 +83,7 @@ namespace CrossCutting.IoC
       services.AddTransient<IUriAppService, UriAppService>();
       services.AddTransient<IEmailService, EmailSenderAppService>();
       services.AddTransient<IYahooFinanceRepository, YahooFinanceRepository>();
+      services.AddTransient<IAzureBlobService, AzureBlobService>();
 
       // Domain - Commands
       services.AddTransient<IRequestHandler<SendEmailCommand, bool>, SendEmailCommandHandler>();
@@ -112,6 +113,7 @@ namespace CrossCutting.IoC
       services.AddTransient<IRequestHandler<GerarSecretAndApiKeyCommand, bool>, GerarSecretAndApiKeyCommandHandler>();
       services.AddTransient<IRequestHandler<AtualizarAboutUsCommand, bool>, AtualizarAboutUsCommandHandler>();
       services.AddTransient<IRequestHandler<AtualizarOHLCCommoditiesRateCommand, bool>, AtualizarOHLCCommoditiesRateCommandHandler>();
+      services.AddTransient<IRequestHandler<DeletePostImageCommand, bool>, DeletePostImageCommandHandler>();
 
       // Domain - Queries
       services.AddTransient<IRequestHandler<ListarSymbolsWithRateQuery, PagedList<Symbols>>, ListarSymbolsWithRateQueryHandler>();

--- a/api-rauscher/Domain/CommandHandlers/Post/DeletePostImageCommandHandler.cs
+++ b/api-rauscher/Domain/CommandHandlers/Post/DeletePostImageCommandHandler.cs
@@ -1,0 +1,55 @@
+using Domain.Commands;
+using Domain.Core.Bus;
+using Domain.Core.Notifications;
+using Domain.Interfaces;
+using Domain.Repositories;
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Domain.CommandHandlers
+{
+  public class DeletePostImageCommandHandler : CommandHandler,
+          IRequestHandler<DeletePostImageCommand, bool>
+  {
+    private readonly IPostRepository _postRepository;
+    private readonly IAzureBlobService _blobService;
+    private readonly IMediatorHandler Bus;
+
+    public DeletePostImageCommandHandler(IPostRepository postRepository,
+                                         IAzureBlobService blobService,
+                                         IUnitOfWork uow,
+                                         IMediatorHandler bus,
+                                         INotificationHandler<DomainNotification> notifications) : base(uow, bus, notifications)
+    {
+      _postRepository = postRepository;
+      _blobService = blobService;
+      Bus = bus;
+    }
+
+    public async Task<bool> Handle(DeletePostImageCommand message, CancellationToken cancellationToken)
+    {
+      if (!message.IsValid())
+      {
+        NotifyValidationErrors(message);
+        return false;
+      }
+
+      var post = _postRepository.GetById(message.PostId);
+      if (post == null)
+      {
+        Bus.RaiseEvent(new DomainNotification(nameof(DeletePostImageCommand), "Post not found."));
+        return false;
+      }
+
+      if (!string.IsNullOrEmpty(post.ImgUrl))
+      {
+        await _blobService.DeleteBlobAsync(post.ImgUrl);
+        post.SetImageUrl(null);
+        _postRepository.Update(post);
+      }
+
+      return Commit();
+    }
+  }
+}

--- a/api-rauscher/Domain/Commands/Post/DeletePostImageCommand.cs
+++ b/api-rauscher/Domain/Commands/Post/DeletePostImageCommand.cs
@@ -1,0 +1,20 @@
+using Domain.Core.Commands;
+using System;
+
+namespace Domain.Commands
+{
+  public class DeletePostImageCommand : PostCommand
+  {
+    public DeletePostImageCommand(Guid postId)
+    {
+      PostId = postId;
+    }
+
+    public Guid PostId { get; }
+
+    public override bool IsValid()
+    {
+      return PostId != Guid.Empty;
+    }
+  }
+}

--- a/api-rauscher/Domain/Interfaces/IAzureBlobService.cs
+++ b/api-rauscher/Domain/Interfaces/IAzureBlobService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Domain.Interfaces
+{
+  public interface IAzureBlobService
+  {
+    Task<bool> DeleteBlobAsync(string blobName);
+  }
+}

--- a/api-rauscher/Domain/Services/AzureBlobService.cs
+++ b/api-rauscher/Domain/Services/AzureBlobService.cs
@@ -1,0 +1,36 @@
+using Azure.Storage.Blobs;
+using Domain.Interfaces;
+using System;
+using System.Threading.Tasks;
+
+namespace Domain.Services
+{
+  public class AzureBlobService : IAzureBlobService
+  {
+    private readonly BlobContainerClient _containerClient;
+
+    public AzureBlobService()
+    {
+      var connectionString = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING");
+      var containerName = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONTAINER");
+
+      if (string.IsNullOrWhiteSpace(connectionString) || string.IsNullOrWhiteSpace(containerName))
+      {
+        throw new InvalidOperationException("Azure storage configuration is missing.");
+      }
+
+      _containerClient = new BlobContainerClient(connectionString, containerName);
+    }
+
+    public async Task<bool> DeleteBlobAsync(string blobName)
+    {
+      if (string.IsNullOrWhiteSpace(blobName))
+      {
+        return false;
+      }
+
+      var response = await _containerClient.DeleteBlobIfExistsAsync(blobName);
+      return response.Value;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Azure blob service and delete post image command
- expose delete post image app service and HTTP API endpoint

## Testing
- `dotnet build api-rauscher.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e2fb63d4c83288051fac8b8d46159